### PR TITLE
Add libical, libreadline requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ libdbus-1-dev
 libudev-dev
 automake
 libtool
+libical-dev
+libreadline-dev
 
 install with: sudo apt-get install or similar
 ```


### PR DESCRIPTION
I found on vanilla Raspbian that I needed to install libical-dev and libreadline-dev when running ./configure --enable-experimental --enable-library for it to complete successfully
